### PR TITLE
enhancement: Add validation errors to PlanResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ with CerbosClient("https://localhost:3592", debug=True, tls_verify=False) as c:
         policy_version="20210210",
         attr={"department": "marketing", "geography": "GB", "team": "design"},
     )
+
+    # Check a single action on a single resource
     r = Resource(
         "XX125",
         "leave_request",
@@ -39,6 +41,11 @@ with CerbosClient("https://localhost:3592", debug=True, tls_verify=False) as c:
         },
     )
     print(c.is_allowed("view:public", p, r))
+
+    # Get the query plan for "view" action
+    rd = ResourceDesc("leave_request", policy_version="20210210")
+    plan = c.plan_resources("view", p, rd)
+    print(plan.filter.to_json())
 ```
 
 Connecting to a Unix domain socket
@@ -67,6 +74,9 @@ with container:
     with CerbosClient(host) as c:
         ...
 ```
+
+
+See the tests available in the `tests` directory for more examples.
 
 ## Get help
 

--- a/cerbos/sdk/model.py
+++ b/cerbos/sdk/model.py
@@ -218,6 +218,7 @@ class PlanResourcesResponse:
     resource_kind: str
     policy_version: str
     filter: Optional[PlanResourcesFilter] = None
+    validation_errors: Optional[List[ValidationError]] = None
     status_code: int = httpx.codes.OK
     status_msg: Optional[APIError] = None
 

--- a/tests/check.py
+++ b/tests/check.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     logging.captureWarnings(True)
 
     with CerbosClient(
-        "unix+https:///tmp/cerbos.sock",
+        "https://localhost:3592",
         playground_instance="XXY",
         debug=True,
         tls_verify=False,
@@ -35,3 +35,7 @@ if __name__ == "__main__":
             },
         )
         print(c.is_allowed("view:public", p, r))
+
+        rd = ResourceDesc("leave_request", policy_version="20210210")
+        plan = c.plan_resources("view", p, rd)
+        print(plan.filter.to_json())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def cerbos_client(request, tmp_path_factory):
     client = None
 
     if request.param == "http":
+        container.with_command("server --set=schema.enforcement=reject")
         container.start()
         container.wait_until_ready()
 
@@ -31,7 +32,7 @@ def cerbos_client(request, tmp_path_factory):
         sock_dir = tmp_path_factory.mktemp("socket")
         container.with_volume_mapping(sock_dir, "/socket", "rw")
         container.with_command(
-            "server --set=server.httpListenAddr=unix:///socket/http.sock --set=server.udsFileMode=0o777"
+            "server --set=server.httpListenAddr=unix:///socket/http.sock --set=server.udsFileMode=0o777 --set=schema.enforcement=reject"
         )
 
         container.start()


### PR DESCRIPTION
Add field to hold validation errors from PlanResources call.

Also adds an example of using the PlanResources method to the README.

Fixes #7

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
