### PR TITLE
fix: Handle `raise_on_error` correctly in async client

### DIFF
--- a/cerbos/sdk/_async/client.py
+++ b/cerbos/sdk/_async/client.py
@@ -64,12 +64,10 @@ class AsyncCerbosClient:
 
         event_hooks = {"response": []}
         if debug:
-            event_hooks["response"].append(
-                lambda response: self._log_response(response)
-            )
+            event_hooks["response"].append(self._log_response)
 
         if raise_on_error:
-            event_hooks["response"].append(lambda response: response.raise_for_status())
+            event_hooks["response"].append(self._raise_on_status)
 
         transport = None
         base_url = host
@@ -91,7 +89,16 @@ class AsyncCerbosClient:
             transport=transport,
         )
 
+    async def _raise_on_status(self, response: httpx.Response):
+        if response is None:
+            return
+
+        response.raise_for_status()
+
     async def _log_response(self, response: httpx.Response):
+        if response is None:
+            return
+
         req_prefix = "< "
         res_prefix = "> "
         request = response.request

--- a/cerbos/sdk/_sync/client.py
+++ b/cerbos/sdk/_sync/client.py
@@ -64,12 +64,10 @@ class CerbosClient:
 
         event_hooks = {"response": []}
         if debug:
-            event_hooks["response"].append(
-                lambda response: self._log_response(response)
-            )
+            event_hooks["response"].append(self._log_response)
 
         if raise_on_error:
-            event_hooks["response"].append(lambda response: response.raise_for_status())
+            event_hooks["response"].append(self._raise_on_status)
 
         transport = None
         base_url = host
@@ -91,7 +89,16 @@ class CerbosClient:
             transport=transport,
         )
 
+    def _raise_on_status(self, response: httpx.Response):
+        if response is None:
+            return
+
+        response.raise_for_status()
+
     def _log_response(self, response: httpx.Response):
+        if response is None:
+            return
+
         req_prefix = "< "
         res_prefix = "> "
         request = response.request

--- a/tests/check.py
+++ b/tests/check.py
@@ -5,7 +5,7 @@ import logging
 
 import anyio
 
-from cerbos.sdk.client import CerbosAsyncClient
+from cerbos.sdk.client import AsyncCerbosClient
 from cerbos.sdk.model import *
 
 
@@ -13,11 +13,12 @@ async def main():
     logging.basicConfig(level=logging.DEBUG)
     logging.captureWarnings(True)
 
-    async with CerbosAsyncClient(
+    async with AsyncCerbosClient(
         "https://localhost:3592",
         playground_instance="XXY",
         debug=True,
         tls_verify=False,
+        raise_on_error=True,
     ) as c:
         p = Principal(
             "john",


### PR DESCRIPTION
When the `raise_on_error` flag is used, the httpx hook would throw an
exception because the lambda is not an awaitable. This PR addresses that
issue.

Fixes #16

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
