### PR TITLE
enhancement: Add support for new `outputs` field in `CheckResources` return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 
 *.pyc
 .pdm-python
+
+.python-version

--- a/cerbos/sdk/model.py
+++ b/cerbos/sdk/model.py
@@ -96,6 +96,13 @@ class ValidationError:
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
+class OutputEntry:
+    src: str
+    val: Any
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass
 class APIError:
     code: int
     message: str
@@ -107,6 +114,7 @@ class CheckResourcesResult:
     resource: Resource
     actions: Dict[str, Effect]
     validation_errors: Optional[List[ValidationError]] = None
+    outputs: Optional[List[OutputEntry]] = None
 
     def is_allowed(self, action: str) -> bool:
         if action in self.actions:

--- a/tests/store/principal_policies/policy_01.yaml
+++ b/tests/store/principal_policies/policy_01.yaml
@@ -14,6 +14,9 @@ principalPolicy:
               expr: variables.is_dev_record
           effect: EFFECT_ALLOW
           name: dev_admin
+          output:
+            expr: |-
+              "dev_record_override:%s".format([P.id])
 
     - resource: salary_record
       actions:

--- a/tests/store/resource_policies/policy_01.yaml
+++ b/tests/store/resource_policies/policy_01.yaml
@@ -38,6 +38,21 @@ resourcePolicy:
         - any_employee
       effect: EFFECT_ALLOW
       name: public-view
+      output:
+        expr: |-
+          {
+            "pID": P.id,
+            "keys": R.attr.id,
+            "formatted_%s".format(["string"]): "id:%s".format([P.id]),
+            "some_bool": true,
+            "some_list": ["foo", "bar"],
+            "something_nested": {
+              "nested_str": "foo",
+              "nested_bool": false,
+              "nested_list": ["nest_foo", 1.01],
+              "nested_formatted_%s".format(["string"]): "id:%s".format([P.id]),
+            },
+          }
 
     - actions: ["approve"]
       condition:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -523,7 +523,9 @@ def _assert_check_resources_with_output(have: CheckResourcesResponse):
     }
 
 
-def _assert_check_resources_principal_override_with_output(have: CheckResourcesResponse):
+def _assert_check_resources_principal_override_with_output(
+    have: CheckResourcesResponse,
+):
     xx125 = have.get_resource(
         "XX125", predicate=lambda r: r.policy_version == "20210210"
     )


### PR DESCRIPTION
Adds support for https://github.com/cerbos/cerbos/pull/1594

closes cerbos/cerbos-sdk-python#23