### PR TITLE
chore(tests): Remove `cerbos.` prefix from output src keys

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -506,7 +506,7 @@ def _assert_check_resources_with_output(have: CheckResourcesResponse):
     assert len(xx125.outputs) == 1
     outputs = xx125.outputs[0].to_dict()
     assert outputs == {
-        "src": "cerbos.resource.leave_request.v20210210#public-view",
+        "src": "resource.leave_request.v20210210#public-view",
         "val": {
             "formatted_string": "id:john",
             "keys": "XX125",
@@ -534,11 +534,11 @@ def _assert_check_resources_principal_override_with_output(
     s = next(filter(lambda x: isinstance(x.val, str), xx125.outputs))
     d = next(filter(lambda x: isinstance(x.val, dict), xx125.outputs))
     assert s.to_dict() == {
-        "src": "cerbos.principal.donald_duck.v20210210#dev_admin",
+        "src": "principal.donald_duck.v20210210#dev_admin",
         "val": "dev_record_override:donald_duck",
     }
     assert d.to_dict() == {
-        "src": "cerbos.resource.leave_request.v20210210#public-view",
+        "src": "resource.leave_request.v20210210#public-view",
         "val": {
             "formatted_string": "id:donald_duck",
             "keys": "XX125",


### PR DESCRIPTION
https://github.com/cerbos/cerbos/pull/1614