### PR TITLE
chore: Lint before build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,8 @@
 
 ### Chores
 
-- Fix formatting
-
-## v0.13.0 (2025-07-18)
-
-### Chores
-
+- Lint before build
+- Fix formatting (#62)
 - Rename Hub list_files `like` filter to `contains` (#60)
 - Update Hub protobufs (#59)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ lint = { cmd = "ruff check --fix src/cerbos/sdk tests utils" }
 format = { composite = ["isort", "ruff_format"] }
 unasync = { cmd = "python utils/gen_unasync.py" }
 test = { cmd = "pytest" }
-pre_build = { composite = ["unasync", "format"] }
-pre_test = { composite = ["unasync", "format"] }
+pre_build = { composite = ["unasync", "format", "lint"] }
+pre_test = { composite = ["unasync", "format", "lint"] }
 
 [tool.ruff.lint]
 ignore = ["F403", "F405"]


### PR DESCRIPTION
The linter was making a change to the code and that results in an impure
build.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
